### PR TITLE
Fixed bug with stdin put in adding values to symbol table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@
 *.app
 
 # Our own
+ciel
 ciel_scanner
 .DS_Store
 *.swp

--- a/parser.ypp
+++ b/parser.ypp
@@ -193,7 +193,7 @@ macro       :   TOK_STDOUT_STREAM TOK_PUT_OP exp TOK_DOT_SBL{
             |   TOK_STDIN_STREAM TOK_PUT_OP TOK_IDENTIFIER TOK_DOT_SBL  {
                                                                             int numTables = contextStack.size();
                                                                             int count = 0;
-                                                                            for(auto symbolTable : contextStack)
+                                                                            for(auto&& symbolTable : contextStack)
                                                                             {
                                                                                 auto element = symbolTable.find($3);
                                                                                 if(element != symbolTable.end()) {
@@ -721,6 +721,7 @@ term   	    : TOK_INTEGER_LIT               {
                                                 {
                                                     auto element = symbolTable.find($1);
                                                     if(element != symbolTable.end()){
+                                                        // std::cout << "Found identifier: " << $1 << " " << symbolTable[$1].value.integer << std::endl;
                                                         switch(symbolTable[$1].type)
                                                         {
                                                             case INTEGER:


### PR DESCRIPTION
# Pull Request Information
* Fix: stdin put <identifier>
* Feature: n/a
* Reason: stdin was not changing the value of the individual variables.
* Additional Comments: a ranged for loop was used but was an iterator value instance of each symbol table, not a reference and thus when changes were made to the table, they weren't present in the master global contextStack symbol tables.
# Checklist
- [x] compiles
- [x] no run-time errors
- [x] tested
- [ ] documented
